### PR TITLE
Implement Security Configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,12 @@
 import os
 import sys
 from importlib.metadata import version as imp_version
+sys.path.insert(0, os.path.abspath('../'))
 
-sys.path.insert(0, os.path.abspath("../"))
 
-
-project = "Quart-Schema"
-copyright = "2020, Philip Jones"
-author = "Philip Jones"
+project = 'Quart-Schema'
+copyright = '2020, Philip Jones'
+author = 'Philip Jones'
 version = imp_version("quart-schema")
 release = version
 
@@ -35,14 +34,14 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 
-source_suffix = ".rst"
+source_suffix = '.rst'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,12 +20,13 @@
 import os
 import sys
 from importlib.metadata import version as imp_version
-sys.path.insert(0, os.path.abspath('../'))
+
+sys.path.insert(0, os.path.abspath("../"))
 
 
-project = 'Quart-Schema'
-copyright = '2020, Philip Jones'
-author = 'Philip Jones'
+project = "Quart-Schema"
+copyright = "2020, Philip Jones"
+author = "Philip Jones"
 version = imp_version("quart-schema")
 release = version
 
@@ -34,14 +35,14 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/src/quart_schema/__init__.py
+++ b/src/quart_schema/__init__.py
@@ -1,4 +1,4 @@
-from .extension import hide_route, QuartSchema, tag
+from .extension import hide_route, QuartSchema, tag, security_scheme
 from .mixins import SchemaValidationError
 from .typing import ResponseReturnValue
 from .validation import (
@@ -24,4 +24,5 @@ __all__ = (
     "validate_querystring",
     "validate_request",
     "validate_response",
+    "security_scheme",
 )

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -301,9 +301,7 @@ def tag(tags: Iterable[str]) -> Callable:
 def security_scheme(schemes: Iterable[Security]) -> Callable:
 
     def decorator(func: Callable) -> Callable:
-        existing_security: List[Security] = getattr(func, QUART_SCHEMA_SECURITY_ATTRIBUTE, list())
-        existing_security.extend(schemes)
-        setattr(func, QUART_SCHEMA_SECURITY_ATTRIBUTE, existing_security)
+        setattr(func, QUART_SCHEMA_SECURITY_ATTRIBUTE, schemes)
 
         return func
 

--- a/src/quart_schema/typing.py
+++ b/src/quart_schema/typing.py
@@ -92,3 +92,13 @@ class ServerObject(TypedDict, total=False):
     url: str
     description: str
     variables: Dict[str, VariableObject]
+
+
+class SecurityScheme(TypedDict, total=False):
+    name: str
+    config: Dict[str, Any]
+
+
+class Security(TypedDict, total=False):
+    name: str
+    scopes: Optional[List[str]]


### PR DESCRIPTION
This is a PR for allowing users to configure [OpenAPI Authentication](https://swagger.io/docs/specification/authentication/) with quart-schema.

There are two steps to this:
1. Defining the security schemes. This is implemented through a constructor parameter similar to the tags. There are various types of schemes (bearer, basic auth, api key), who all need different config, so I decided to just allow the user to pass in arbitrary dicts. One could consider building types for this (`BearerSecurityScheme`, `BasicAuthSecurityScheme`, etc...), but this can grow quite complex with Oauth2, etc.
2. Applying the schemes to routes. This can happen either globally - again through a constructor parameter. Or, through an annotation on the route, again similar to the tags. If the annotation is used, all globally applied schemes are overridden.

Sample code:

```python
def create_app():
    ...

    QuartSchema(
        app,
        security_schemes=[
            SecurityScheme(name="MyBearer", config={"type": "http", "scheme": "bearer"}), 
            SecurityScheme(name="MyBasicAuth", config={"type": "http", "scheme": "basic"})
        ],
        security=[Security(name="MyBearer")],
    )

# on route level, override auth scheme, to no auth required:
@security_scheme([])
@app.get("/hello_world")
async def hello_world() -> Response:
    pass

# on route level, override global bearer with basic auth:
@security_scheme([Security(name="MyBasicAuth")])
@app.get("/foobar")
async def foobar() -> Response:
    pass

```

Besides missing documentation this implementation is imo actually complete and functioning as is.