### PR TITLE
Fix query and header description

### DIFF
--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -373,13 +373,11 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
             definitions, schema = _split_definitions(schema)
             components["schemas"].update(definitions)
             for name, type_ in schema["properties"].items():
-                path_object["parameters"].append(  # type: ignore
-                    {
-                        "name": name,
-                        "in": "query",
-                        "schema": type_,
-                    }
-                )
+                param = {"name": name, "in": "query", "schema": type_}
+                if "description" in type_:
+                    param["description"] = type_.pop("description")
+
+                path_object["parameters"].append(param)
 
         headers_model = getattr(func, QUART_SCHEMA_HEADERS_ATTRIBUTE, None)
         if headers_model is not None:
@@ -387,13 +385,11 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
             definitions, schema = _split_definitions(schema)
             components["schemas"].update(definitions)
             for name, type_ in schema["properties"].items():
-                path_object["parameters"].append(  # type: ignore
-                    {
-                        "name": name.replace("_", "-"),
-                        "in": "header",
-                        "schema": type_,
-                    }
-                )
+                param = {"name": name.replace("_", "-"), "in": "header", "schema": type_}
+                if "description" in type_:
+                    param["description"] = type_.pop("description")
+
+                path_object["parameters"].append(param)
 
         for name, converter in rule._converters.items():
             type_ = "string"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from pydantic import Field
 from quart import Quart
 
 from quart_schema import (
@@ -14,7 +15,7 @@ from quart_schema import (
 
 @dataclass
 class QueryItem:
-    count_le: Optional[int] = None
+    count_le: Optional[int] = Field(description="count_le description")
 
 
 @dataclass
@@ -30,7 +31,7 @@ class Result:
 
 @dataclass
 class Headers:
-    x_name: str
+    x_name: str = Field(..., description="x-name description")
 
 
 async def test_openapi() -> None:
@@ -58,11 +59,13 @@ async def test_openapi() -> None:
                         {
                             "in": "query",
                             "name": "count_le",
+                            "description": "count_le description",
                             "schema": {"title": "Count Le", "type": "integer"},
                         },
                         {
                             "in": "header",
                             "name": "x-name",
+                            "description": "x-name description",
                             "schema": {"title": "X Name", "type": "string"},
                         },
                     ],
@@ -93,7 +96,13 @@ async def test_openapi() -> None:
                                     }
                                 },
                                 "headers": {
-                                    "x-name": {"schema": {"title": "X Name", "type": "string"}}
+                                    "x-name": {
+                                        "schema": {
+                                            "title": "X Name",
+                                            "type": "string",
+                                            "description": "x-name description",
+                                        }
+                                    }
                                 },
                             },
                             "description": "Result(name: str)",


### PR DESCRIPTION
According to the OpenAPI specification, the descriptions of headers and querystrings shouldn't be within the `schema` section, but one level above.