### PR TITLE
increase swagger version to 4.12.0

### DIFF
--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -182,11 +182,11 @@ class QuartSchema:
         app.make_response = convert_model_result(app.make_response)  # type: ignore
         app.config.setdefault(
             "QUART_SCHEMA_SWAGGER_JS_URL",
-            "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.47.1/swagger-ui-bundle.js",
+            "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui-bundle.js",
         )
         app.config.setdefault(
             "QUART_SCHEMA_SWAGGER_CSS_URL",
-            "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.47.1/swagger-ui.min.css",
+            "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.12.0/swagger-ui.min.css",
         )
         app.config.setdefault(
             "QUART_SCHEMA_REDOC_JS_URL",


### PR DESCRIPTION
Version 3.x is no longer supported: https://swagger.io/blog/news/what-s-new-in-swaggerui-v4-and-swaggereditor-v4/

It's a major version change, but everything looks & works the same as it did before.