### PR TITLE
Render endpoint description not as code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,12 @@
 import os
 import sys
 from importlib.metadata import version as imp_version
+sys.path.insert(0, os.path.abspath('../'))
 
-sys.path.insert(0, os.path.abspath("../"))
 
-
-project = "Quart-Schema"
-copyright = "2020, Philip Jones"
-author = "Philip Jones"
+project = 'Quart-Schema'
+copyright = '2020, Philip Jones'
+author = 'Philip Jones'
 version = imp_version("quart-schema")
 release = version
 
@@ -35,14 +34,14 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
 
-source_suffix = ".rst"
+source_suffix = '.rst'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,12 +20,13 @@
 import os
 import sys
 from importlib.metadata import version as imp_version
-sys.path.insert(0, os.path.abspath('../'))
+
+sys.path.insert(0, os.path.abspath("../"))
 
 
-project = 'Quart-Schema'
-copyright = '2020, Philip Jones'
-author = 'Philip Jones'
+project = "Quart-Schema"
+copyright = "2020, Philip Jones"
+author = "Philip Jones"
 version = imp_version("quart-schema")
 release = version
 
@@ -34,14 +35,14 @@ release = version
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import re
 from collections.abc import Mapping
@@ -306,8 +307,8 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
             "responses": {},
         }
         if func.__doc__ is not None:
-            summary, *description = func.__doc__.splitlines()
-            path_object["description"] = "\n".join([line.strip() for line in description])
+            summary, *description = inspect.getdoc(func).splitlines()
+            path_object["description"] = "\n".join(description)
             path_object["summary"] = summary
 
         if getattr(func, QUART_SCHEMA_TAG_ATTRIBUTE, None) is not None:

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -331,7 +331,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
                 "description": "",
             }
             if model_class.__doc__ is not None:
-                response_object["description"] = model_class.__doc__
+                response_object["description"] = inspect.getdoc(model_class)
 
             if headers_model_class is not None:
                 schema = model_schema(headers_model_class, ref_prefix=REF_PREFIX)

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -307,7 +307,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
         }
         if func.__doc__ is not None:
             summary, *description = func.__doc__.splitlines()
-            path_object["description"] = "\n".join(description)
+            path_object["description"] = "\n".join([line.strip() for line in description])
             path_object["summary"] = summary
 
         if getattr(func, QUART_SCHEMA_TAG_ATTRIBUTE, None) is not None:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -45,7 +45,13 @@ async def test_openapi() -> None:
     async def index() -> Tuple[Result, int, Headers]:
         """Summary
         Multi-line
-        description."""
+        description.
+
+        This is a new paragraph
+
+            And this is an indented codeblock.
+
+        And another paragraph."""
         return Result(name="bob"), 200, Headers(x_name="jeff")
 
     test_client = app.test_client()
@@ -58,7 +64,8 @@ async def test_openapi() -> None:
             "/": {
                 "get": {
                     "summary": "Summary",
-                    "description": "Multi-line\ndescription.",
+                    "description": "Multi-line\ndescription.\n\nThis is a new paragraph\n\n    And this is an indented "
+                    "codeblock.\n\nAnd another paragraph.",
                     "parameters": [
                         {
                             "in": "query",

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -43,6 +43,9 @@ async def test_openapi() -> None:
     @validate_headers(Headers)
     @validate_response(Result, 200, Headers)
     async def index() -> Tuple[Result, int, Headers]:
+        """Summary
+        Multi-line
+        description."""
         return Result(name="bob"), 200, Headers(x_name="jeff")
 
     test_client = app.test_client()
@@ -54,6 +57,8 @@ async def test_openapi() -> None:
         "paths": {
             "/": {
                 "get": {
+                    "summary": "Summary",
+                    "description": "Multi-line\ndescription.",
                     "parameters": [
                         {
                             "in": "query",


### PR DESCRIPTION
Swagger renders the Endpoint Summary with Markdown. And since the route documentation usually has at least one level of indentation, there are 4 spaces at the start of every line. Therefore Markdown interprets the summary as code and the entire description is being rendered in a code block, which is kinda weird.

Luckily the standard library has [a method](https://docs.python.org/3.6/library/inspect.html#inspect.getdoc) that removes the initial whitespace for us, while preserving any additional indentation, so you can continue to render codeblocks.