### PR TITLE
add deprecation decorator

### DIFF
--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -32,6 +32,7 @@ from .validation import (
 QUART_SCHEMA_HIDDEN_ATTRIBUTE = "_quart_schema_hidden"
 QUART_SCHEMA_TAG_ATTRIBUTE = "_quart_schema_tag"
 QUART_SCHEMA_SECURITY_ATTRIBUTE = "_quart_schema_security_tag"
+QUART_SCHEMA_DEPRECATED = "_quart_schema_deprecated"
 REF_PREFIX = "#/components/schemas/"
 
 PATH_RE = re.compile("<(?:[^:]*:)?([^>]+)>")
@@ -329,6 +330,17 @@ def tag(tags: Iterable[str]) -> Callable:
     return decorator
 
 
+def deprecated() -> Callable:
+    """Mark endpoint as deprecated."""
+
+    def decorator(func: Callable) -> Callable:
+        setattr(func, QUART_SCHEMA_DEPRECATED, True)
+
+        return func
+
+    return decorator
+
+
 def security_scheme(schemes: Iterable[Dict[str, List[str]]]) -> Callable:
     """Add security schemes to the route.
 
@@ -371,6 +383,9 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
 
         if getattr(func, QUART_SCHEMA_TAG_ATTRIBUTE, None) is not None:
             operation_object["tags"] = list(getattr(func, QUART_SCHEMA_TAG_ATTRIBUTE))
+
+        if getattr(func, QUART_SCHEMA_DEPRECATED, None):
+            operation_object["deprecated"] = True
 
         if getattr(func, QUART_SCHEMA_SECURITY_ATTRIBUTE, None) is not None:
             operation_object["security"] = list(getattr(func, QUART_SCHEMA_SECURITY_ATTRIBUTE))

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -372,7 +372,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
         if getattr(func, QUART_SCHEMA_HIDDEN_ATTRIBUTE, False):
             continue
 
-        operation_object = {  # type: ignore
+        operation_object: Dict[str, Any] = {  # type: ignore
             "parameters": [],
             "responses": {},
         }

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -372,7 +372,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
         if getattr(func, QUART_SCHEMA_HIDDEN_ATTRIBUTE, False):
             continue
 
-        operation_object: Dict[str, Any] = {  # type: ignore
+        operation_object: Dict[str, Any] = {
             "parameters": [],
             "responses": {},
         }
@@ -417,7 +417,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
                     }
                     for name, type_ in schema["properties"].items()
                 }
-            operation_object["responses"][status_code] = response_object  # type: ignore
+            operation_object["responses"][status_code] = response_object
 
         request_data = getattr(func, QUART_SCHEMA_REQUEST_ATTRIBUTE, None)
         if request_data is not None:
@@ -450,7 +450,7 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
                     if attribute in type_:
                         param[attribute] = type_.pop(attribute)
 
-                operation_object["parameters"].append(param)  # type: ignore
+                operation_object["parameters"].append(param)
 
         headers_model = getattr(func, QUART_SCHEMA_HEADERS_ATTRIBUTE, None)
         if headers_model is not None:
@@ -464,14 +464,14 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
                     if attribute in type_:
                         param[attribute] = type_.pop(attribute)
 
-                operation_object["parameters"].append(param)  # type: ignore
+                operation_object["parameters"].append(param)
 
         for name, converter in rule._converters.items():
             type_ = "string"
             if isinstance(converter, NumberConverter):
                 type_ = "number"
 
-            operation_object["parameters"].append(  # type: ignore
+            operation_object["parameters"].append(
                 {
                     "name": name,
                     "in": "path",

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -445,8 +445,10 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
             components["schemas"].update(definitions)
             for name, type_ in schema["properties"].items():
                 param = {"name": name, "in": "query", "schema": type_}
-                if "description" in type_:
-                    param["description"] = type_.pop("description")
+
+                for attribute in ("description", "required", "deprecated"):
+                    if attribute in type_:
+                        param[attribute] = type_.pop(attribute)
 
                 operation_object["parameters"].append(param)  # type: ignore
 
@@ -457,8 +459,10 @@ def _build_openapi_schema(app: Quart, extension: QuartSchema) -> dict:
             components["schemas"].update(definitions)
             for name, type_ in schema["properties"].items():
                 param = {"name": name.replace("_", "-"), "in": "header", "schema": type_}
-                if "description" in type_:
-                    param["description"] = type_.pop("description")
+
+                for attribute in ("description", "required", "deprecated"):
+                    if attribute in type_:
+                        param[attribute] = type_.pop(attribute)
 
                 operation_object["parameters"].append(param)  # type: ignore
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -12,6 +12,7 @@ from quart_schema import (
     validate_request,
     validate_response,
 )
+from quart_schema.extension import deprecated
 
 
 @dataclass
@@ -32,7 +33,7 @@ class Result:
 
 @dataclass
 class Headers:
-    x_name: str = Field(..., description="x-name description")
+    x_name: str = Field(..., description="x-name description", deprecated=True)
 
 
 async def test_openapi() -> None:
@@ -44,6 +45,7 @@ async def test_openapi() -> None:
     @validate_request(Details)
     @validate_headers(Headers)
     @validate_response(Result, 200, Headers)
+    @deprecated()
     async def index() -> Tuple[Result, int, Headers]:
         """Summary
         Multi-line
@@ -72,6 +74,7 @@ async def test_openapi() -> None:
                     "summary": "Summary",
                     "description": "Multi-line\ndescription.\n\nThis is a new paragraph\n\n    "
                     "And this is an indented codeblock.\n\nAnd another paragraph.",
+                    "deprecated": True,
                     "parameters": [
                         {
                             "in": "query",
@@ -83,6 +86,7 @@ async def test_openapi() -> None:
                             "in": "header",
                             "name": "x-name",
                             "description": "x-name description",
+                            "deprecated": True
                             "schema": {"title": "X Name", "type": "string"},
                         },
                     ],

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -122,7 +122,7 @@ async def test_openapi() -> None:
                                             "title": "X Name",
                                             "type": "string",
                                             "description": "x-name description",
-                                            "deprecated": True
+                                            "deprecated": True,
                                         }
                                     }
                                 },

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -86,7 +86,7 @@ async def test_openapi() -> None:
                             "in": "header",
                             "name": "x-name",
                             "description": "x-name description",
-                            "deprecated": True
+                            "deprecated": True,
                             "schema": {"title": "X Name", "type": "string"},
                         },
                     ],

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -122,6 +122,7 @@ async def test_openapi() -> None:
                                             "title": "X Name",
                                             "type": "string",
                                             "description": "x-name description",
+                                            "deprecated": True
                                         }
                                     }
                                 },


### PR DESCRIPTION
* Adds a new decorator `@deprecated`
* Adds `deprecated` parameter to headers and queries
* Also adds the `required` parameter to headers and queries (Btw: Why are required query parameters explicitly disallowed? [The openapi specs allows this.](https://swagger.io/specification/#parameter-object))