### PR TITLE
feat: document_response decorator

### DIFF
--- a/src/quart_schema/__init__.py
+++ b/src/quart_schema/__init__.py
@@ -1,3 +1,4 @@
+from .documentation import document_response
 from .extension import deprecate, hide, QuartSchema, security_scheme, tag
 from .mixins import SchemaValidationError
 from .openapi import (
@@ -29,6 +30,7 @@ __all__ = (
     "Contact",
     "DataSource",
     "deprecate",
+    "document_response",
     "ExternalDocumentation",
     "hide",
     "HttpSecurityScheme",

--- a/src/quart_schema/documentation.py
+++ b/src/quart_schema/documentation.py
@@ -1,0 +1,39 @@
+from typing import Callable, Optional
+from quart import ResponseReturnValue as QuartResponseReturnValue
+from .typing import Model
+from .validation import QUART_SCHEMA_RESPONSE_ATTRIBUTE, _to_pydantic_model
+
+
+def document_response(
+    model_class: Model,
+    status_code: int = 200,
+    headers_model_class: Optional[Model] = None,
+) -> Callable:
+    """Document the response data.
+
+    Add the response **model_class**, and its corresponding (optional)
+    **headers_model_class** to the openapi generated documentation.
+
+    Arguments:
+        model_class: The model to use, either a dataclass, pydantic
+            dataclass or a class that inherits from pydantic's
+            BaseModel.
+        status_code: The status code this validation applies
+            to. Defaults to 200.
+        headers_model_class: The model to use to document the response
+            headers, either a dataclass, pydantic dataclass or a class
+            that inherits from pydantic's BaseModel. Is optional.
+    """
+    model_class = _to_pydantic_model(model_class)
+    headers_model_class = _to_pydantic_model(headers_model_class)
+
+    def decorator(
+        func: Callable[..., QuartResponseReturnValue]
+    ) -> Callable[..., QuartResponseReturnValue]:
+        schemas = getattr(func, QUART_SCHEMA_RESPONSE_ATTRIBUTE, {})
+        schemas[status_code] = (model_class, headers_model_class)
+        setattr(func, QUART_SCHEMA_RESPONSE_ATTRIBUTE, schemas)
+
+        return func
+
+    return decorator


### PR DESCRIPTION
Simply add the response documentation without validating it at runtime.