### PR TITLE
Add support for request File types

### DIFF
--- a/docs/how_to_guides/request_validation.rst
+++ b/docs/how_to_guides/request_validation.rst
@@ -69,3 +69,41 @@ with everything working as in the JSON example above.
    Form encoded data is a flat structure, therefore Quart-Schema will
    raise a ``SchemaInvalidError`` if the model proposed has nested
    structures.
+
+Files
+---------
+
+If your route receives files through a (multipart/form-data) encoded body, 
+use the ``File`` class to check the request.
+
+For a HTML form which accepts one or several files
+
+.. code-block:: HTML
+
+    <form action="/post" method="POST" enctype="multipart/form-data">
+        <input type="file" "name="images" multiple>
+        <input type="file" name="video">
+        <input type="text" name="text">
+        <input type="submit" value="Submit">
+    </form>
+
+use a ``File`` or ``list[File]`` type hint to validate the request
+
+.. code-block:: python
+
+    from dataclasses import dataclass
+
+    from quart_schema import DataSource, File, validate_request
+
+    @dataclass
+    class RichPost:
+        images: list[File]
+        video: File
+        text: str
+
+    @app.route("/rich_post", methods=["POST'])
+    @validate_request(RichPost, source=DataSource.FORM)
+    async def post(data: RichPost):
+        video = data.video.save(...)
+        image = data.images[0].save(...)
+        ...

--- a/docs/how_to_guides/request_validation.rst
+++ b/docs/how_to_guides/request_validation.rst
@@ -71,7 +71,7 @@ with everything working as in the JSON example above.
    structures.
 
 Files
----------
+-----
 
 If your route receives files through a (multipart/form-data) encoded body, 
 use the ``File`` class to check the request.
@@ -80,7 +80,7 @@ For a HTML form which accepts one or several files
 
 .. code-block:: HTML
 
-    <form action="/post" method="POST" enctype="multipart/form-data">
+    <form action="/rich_post" method="POST" enctype="multipart/form-data">
         <input type="file" "name="images" multiple>
         <input type="file" name="video">
         <input type="text" name="text">
@@ -103,7 +103,7 @@ use a ``File`` or ``list[File]`` type hint to validate the request
 
     @app.route("/rich_post", methods=["POST'])
     @validate_request(RichPost, source=DataSource.FORM)
-    async def post(data: RichPost):
+    async def rich_post(data: RichPost):
         video = data.video.save(...)
         image = data.images[0].save(...)
         ...

--- a/src/quart_schema/__init__.py
+++ b/src/quart_schema/__init__.py
@@ -20,7 +20,7 @@ from .openapi import (
     ServerVariable,
     Tag,
 )
-from .typing import ResponseReturnValue
+from .typing import File, ResponseReturnValue
 from .validation import (
     DataSource,
     RequestSchemaValidationError,
@@ -43,6 +43,7 @@ __all__ = (
     "document_request",
     "document_response",
     "ExternalDocumentation",
+    "File",
     "hide",
     "HttpSecurityScheme",
     "Info",

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -31,6 +31,7 @@ from .openapi import (
     Server,
     Tag,
 )
+from .typing import has_files
 from .validation import (
     DataSource,
     QUART_SCHEMA_HEADERS_ATTRIBUTE,
@@ -471,7 +472,11 @@ def _build_path(func: Callable, rule: Rule, app: Quart) -> Tuple[dict, dict]:
         if request_data[1] == DataSource.JSON:
             encoding = "application/json"
         else:
-            encoding = "application/x-www-form-urlencoded"
+            schema_has_files, _ = has_files(schema)
+            if schema_has_files:
+                encoding = "multipart/form-data"
+            else:
+                encoding = "application/x-www-form-urlencoded"
 
         operation_object["requestBody"] = {
             "content": {


### PR DESCRIPTION
This is a PR to solve #37

It adds a `File` class (a subclass of `FileStorage`) which can be used for type hints, either by itself or as `list[File]`

`validate_request()` awaits `request.files` and puts the `FileStorage` objects into the appropriate `data` field. If we're expecting a list of files, we call `MultiDict.getlist()` to get all the files that were provided.

`_build_path()` recognizes the presence of `File` and `list[File]` in the schema, and changes the encoding to `multipart/form-data`

Also modified the documentation to explain how to use this