### PR TITLE
Force Pydantic V1 to be used, as V2 is not yet supported and causing errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.16.1 2023-07-10
+-----------------
+
+* Force Pydantic V1 to be used, as V2 is not yet supported.
+
 0.16.0 2023-05-08
 -----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quart-schema"
-version = "0.16.0"
+version = "0.16.1"
 description = "A Quart extension to provide schema validation"
 authors = ["pgjones <philip.graham.jones@googlemail.com>"]
 classifiers = [
@@ -60,7 +60,7 @@ warn_unused_ignores = true
 pydata_sphinx_theme = { version = "*", optional = true }
 pyhumps = ">=1.6.1"
 python = ">=3.7"
-pydantic=">=1.10"
+pydantic=">=1.10,<2.0"
 quart = ">=0.18.1"
 typing_extensions = { version = "*", python = "<3.8" }
 


### PR DESCRIPTION
Addressing #46

I believe the failing test in the CI is related to this [Quart PR](https://github.com/pallets/quart/pull/248) because it's causing [similar errors](https://github.com/pallets/quart/actions/runs/5494870780/jobs/10013913632).