### PR TITLE
Add support for enums in route parameters

### DIFF
--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -16,7 +16,7 @@ from pydantic.json_schema import GenerateJsonSchema
 from quart import current_app, Quart, render_template_string, Response, ResponseReturnValue
 from quart.cli import pass_script_info, ScriptInfo
 from quart.json.provider import DefaultJSONProvider
-from werkzeug.routing.converters import NumberConverter
+from werkzeug.routing.converters import NumberConverter, AnyConverter
 from werkzeug.routing.rules import Rule
 
 from .mixins import TestClientMixin, WebsocketMixin
@@ -549,12 +549,17 @@ def _build_path(func: Callable, rule: Rule, app: Quart) -> Tuple[dict, dict]:
         if isinstance(converter, NumberConverter):
             type_ = "number"
 
+        schema = {"type": type_}
+
+        if isinstance(converter, AnyConverter):
+            schema["enum"] = list(converter.items)
+
         operation_object["parameters"].append(
             {
                 "name": name,
                 "in": "path",
                 "required": True,
-                "schema": {"type": type_},
+                "schema": schema,
             }
         )
 


### PR DESCRIPTION
Add support for enums in route parameters by using Werkzeug's built-in [any() converter](https://werkzeug.palletsprojects.com/en/3.0.x/routing/#werkzeug.routing.AnyConverter).
E.g. route
```python
@app.get('/<any("nyse", "nasdaq"):market>/<stock_id>')
async def get_price(market, stock_id):
   """Get stock price"""
   ...
```
renders as 

![image](https://github.com/pgjones/quart-schema/assets/23497198/452f4222-c0a3-4909-8f40-4bece93e696f)


