### PR TITLE
Replace pydantic_encoder with to_jsonable_python

### DIFF
--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -11,8 +11,8 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 import click
 from humps import camelize
 from pydantic import BaseModel
-from pydantic.json import pydantic_encoder
 from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core import to_jsonable_python
 from quart import current_app, Quart, render_template_string, Response, ResponseReturnValue
 from quart.cli import pass_script_info, ScriptInfo
 from quart.json.provider import DefaultJSONProvider
@@ -113,7 +113,7 @@ class JSONProvider(DefaultJSONProvider):
         try:
             return super().default(object_)
         except TypeError:
-            return pydantic_encoder(object_)
+            return to_jsonable_python(object_)
 
 
 def hide(func: Callable) -> Callable:


### PR DESCRIPTION
pydantic_encoder is deprecated in Pydantic v2 and triggers a `DeprecationWarning`.

I'm not sure what's happening with the test failures, they happen for me on the main branch too (presumably some newer dependency versions have changed behaviour slightly).