### PR TITLE
better handling of status when returning a response

### DIFF
--- a/src/quart_schema/validation.py
+++ b/src/quart_schema/validation.py
@@ -225,12 +225,14 @@ def validate_response(
             status = 200
             if isinstance(status_or_headers, int):
                 status = int(status_or_headers)
+            elif isinstance(value, (Response, WerkzeugResponse)):
+                status = value.status_code
 
             if isinstance(value, (Response, WerkzeugResponse)):
-                if value.status_code == status_code:
+                if status == status_code:
                     raise ResponseHeadersValidationError()
                 else:
-                    return value
+                    return result
 
             if status == status_code:
                 try:


### PR DESCRIPTION
This change makes the [handling of returned responses](https://github.com/pgjones/quart-schema/commit/b5c610ba89a93b260edbd6ffe68eac68e7574338) work even if an explicit status code is returned as a second argument, i.e. if the return type is `tuple[Response, int]`.

An example of this would be for instance:

```py
@bp.route("/", methods=["PUT"])
@validate_response(MyDataclass, 201)
async def update():
    return jsonify({"status": "created"}), 201
```

In this case the status code would be mistaken for 200 and the response would be returned as-is without validation.

Moreover, in the case the validator should be transparent because it is a different status code, the current code would ignore the status code and header.

Also (not addressed in this PR but related) in the case where it works, I was surprised that the error returned here is `ResponseHeadersValidationError`. I could not understand why I got this without reading the source code. In my opinion, since this is a programming error, it would make more sense to use a different error class with a clear error message or even an assertion.