### PR TITLE
Fix form multiselect request validation

### DIFF
--- a/src/quart_schema/validation.py
+++ b/src/quart_schema/validation.py
@@ -155,7 +155,10 @@ def validate_request(
             if source == DataSource.JSON:
                 data = await request.get_json()
             else:
-                data = (await request.form).to_dict()
+                data = (await request.form).to_dict(flat=False)
+                for key, value in data.items():
+                    if len(value) == 1:
+                        data[key] = value[0]
                 if source == DataSource.FORM_MULTIPART:
                     files = await request.files
                     for key in files:


### PR DESCRIPTION
When using a FORM Datasource, if a multiselect field is present, quart-schema will fail to validate the data.

This is because MultiDict.to_dict() returns only the first occurrence of each key by default.

By using flat=True this PR fixes this.


ref: https://stackoverflow.com/questions/51992901/capture-values-from-multiple-select-form-and-post-via-flask 

https://werkzeug.palletsprojects.com/en/3.0.x/datastructures/#werkzeug.datastructures.MultiDict.to_dict 