### PR TITLE
Update README.rst to use Scalar instead ScalaR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ The documentation is served by default at ``/openapi.json`` according
 to the OpenAPI standard, or at ``/docs`` for a `SwaggerUI
 <https://swagger.io/tools/swagger-ui/>`_ interface, or ``/redocs`` for
 a `redoc <https://github.com/Redocly/redoc>`_ interface, or
-``/scalar`` for a `ScalaR <https://github.com/ScalaR/ScalaR>`_
+``/scalar`` for a `Scalar <https://github.com/scalar/scalar>`_
 interface. Note that there is currently no documentation standard for
 WebSockets.
 


### PR DESCRIPTION
Hey, we saw you added the Scalar API Reference to your repo, that’s so cool! Big Python fans here.

Just a minor nitpick: It should be Scalar (instead of ScalaR). ✌️