### PR TITLE
Enhance Open API schema generation for pydantic response models

### DIFF
--- a/src/quart_schema/conversion.py
+++ b/src/quart_schema/conversion.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import fields, is_dataclass
 from inspect import isclass
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union
 
 import humps
 from quart import current_app
@@ -72,6 +72,8 @@ PYDANTIC_REF_TEMPLATE = "#/components/schemas/{model}"
 MSGSPEC_REF_TEMPLATE = "#/components/schemas/{name}"
 
 T = TypeVar("T", bound=Model)
+
+JsonSchemaMode = Literal['validation', 'serialization']
 
 
 def convert_response_return_value(
@@ -184,9 +186,9 @@ def model_load(
         raise exception_class(error)
 
 
-def model_schema(model_class: Type[Model], *, preference: Optional[str] = None) -> dict:
+def model_schema(model_class: Type[Model], *, preference: Optional[str] = None, schema_mode: JsonSchemaMode = "validation") -> dict:
     if _use_pydantic(model_class, preference):
-        return TypeAdapter(model_class).json_schema(ref_template=PYDANTIC_REF_TEMPLATE)
+        return TypeAdapter(model_class).json_schema(ref_template=PYDANTIC_REF_TEMPLATE, mode=schema_mode)
     elif _use_msgspec(model_class, preference):
         _, schema = schema_components([model_class], ref_template=MSGSPEC_REF_TEMPLATE)
         return list(schema.values())[0]

--- a/src/quart_schema/extension.py
+++ b/src/quart_schema/extension.py
@@ -488,7 +488,9 @@ def _build_path(func: Callable, rule: Rule, app: Quart) -> Tuple[dict, dict]:
     for status_code in response_models.keys():
         model_class, headers_model_class = response_models[status_code]
         schema = model_schema(
-            model_class, preference=app.config["QUART_SCHEMA_CONVERSION_PREFERENCE"]
+            model_class,
+            preference=app.config["QUART_SCHEMA_CONVERSION_PREFERENCE"],
+            schema_mode="serialization",
         )
         definitions, schema = _split_convert_definitions(
             schema, app.config["QUART_SCHEMA_CONVERT_CASING"]


### PR DESCRIPTION
Enhance pydantic model schema generation
- For pydantic based models, enhance the Open API schema generation by differentiating between "validation" and "serialization" models.
- The default mode used by the pydantic TypeAdapter when generating JSON schemas is a "validation" schema.
- Add an additional option to the `model_schema` function in `quart-schema/src/quart-schema/conversion.py` called `schema_mode` that will execute the TypeAdapter schema generation in the selected mode. Keep the same default of "validation".
- When generating Open API paths for response models specifically, change the schema_mode to "serialization" instead of "validation". This allows us to use models that have custom fields (e.g. computed fields or custom serialization logic) to be correctly converted to an Open API schema.

Added tests that demonstrate a very simple use case where you are using computed fields on a pydantic model:

```python
from pydantic import BaseModel, computed_field
from quart import Quart
from quart_schema import QuartSchema, validate_response

class EmployeeWithComputedField(BaseModel):
    first_name: str
    last_name: str

    @computed_field
    @property
    def full_name(self) -> str:
        return f"{self.first_name} {self.last_name}"


async def test_response_model_with_computed_field():
    """
    Test that routes returning a response model that has one or more computed fields have the
    appropriate properties in the generated JSON schema.
    """
    app = Quart(__name__)
    QuartSchema(app, convert_casing=True)

    @app.route("/")
    @validate_response(EmployeeWithComputedField)
    async def index() -> EmployeeWithComputedField:
        return EmployeeWithComputedField(first_name="Jane", last_name="Doe")

    test_client = app.test_client()
    response = await test_client.get("/openapi.json")
    schema = await response.get_json()

    response_properties = schema["paths"]["/"]["get"]["responses"]["200"]["content"][
        "application/json"
    ]["schema"]["properties"]

    assert "firstName" in response_properties
    assert "lastName" in response_properties
    assert "fullName" in response_properties
```

The last assert (`assert "fullName" in response_properties`) will fail in the current version of quart schema as computed fields are only added to the JSON schema when the mode is set to "serialization" and the default for the pydantic `TypeAdapter`  is "validation". This makes sense for data models being sent to the server where we can just re-generate the computed field so there is no need to include these fields in the incoming JSON. For responses however, it makes sense to include the computed field value as there may be custom serialization occurring that is non-trivial to re-implement on the client side.