### PR TITLE
ServerVariable.enum should be an optional list of strings

### DIFF
--- a/src/quart_schema/openapi.py
+++ b/src/quart_schema/openapi.py
@@ -516,7 +516,7 @@ class ServerVariable(_SchemaBase):
             allows CommonMark syntax.
     """
 
-    enum: str
+    enum: Optional[List[str]]
     default: str
     description: Optional[str] = None
 


### PR DESCRIPTION
According to the specification [1], server variable enum property should be an array of strings. Not required.

[1] https://swagger.io/specification/#server-variable-object