### PR TITLE
Add 'mode' field to PydanticDumpOptions TypedDict

### DIFF
--- a/src/quart_schema/typing.py
+++ b/src/quart_schema/typing.py
@@ -91,6 +91,7 @@ class TestClientProtocol(Protocol):
 
 
 class PydanticDumpOptions(TypedDict):
+    mode: NotRequired[Literal['json', 'python']]
     by_alias: NotRequired[bool]
     exclude_defaults: NotRequired[bool]
     exclude_none: NotRequired[bool]


### PR DESCRIPTION
This is used when objects like IPv4Address or other custom objects is not reconised by the json serializer.

Often you want your model_dump to give you the object not serialized like IPv4Addresses, but you want `model_dump(mode="json")` to give you the string.

I would even suggest that `mode="json"` should be default, but I'm afraid that would break som peoples code.

```python
from ipaddress import IPv4Address
import pydantic

class Demo(pydantic.BaseModel):
    ip: IPv4Address


d = Demo(ip=IPv4Address("127.0.0.1"))
d.model_dump()
# {'ip': IPv4Address('127.0.0.1')}
d.model_dump(mode="json")
# {'ip': '127.0.0.1'}
```