### PR TITLE
Fix typo in  security scheme Docs parameter name

### DIFF
--- a/docs/how_to_guides/security_schemes.rst
+++ b/docs/how_to_guides/security_schemes.rst
@@ -15,7 +15,7 @@ passed as a querry arg called ``appID``:
         app,
         security=[{"app_id": []}],
         security_schemes={
-            "app_id": {"type": "apiKey", "name": "appID", "in": "query"}
+            "app_id": {"type": "apiKey", "name": "appID", "in_": "query"}
         },
     )
 


### PR DESCRIPTION
The key for the location is now `in_`