### PR TITLE
Include defs in msgspec schema

### DIFF
--- a/src/quart_schema/conversion.py
+++ b/src/quart_schema/conversion.py
@@ -208,7 +208,11 @@ def model_schema(
         )
     elif _use_msgspec(model_class, preference):
         _, schema = schema_components([model_class], ref_template=MSGSPEC_REF_TEMPLATE)
-        return list(schema.values())[0]
+        schema_name = list(schema.keys())[0]
+        main_schema = schema.pop(schema_name)
+        if schema:  # Remaining schemas (like Attribute) become $defs
+            main_schema["$defs"] = schema
+        return main_schema
     elif not PYDANTIC_INSTALLED and not MSGSPEC_INSTALLED:
         raise TypeError(
             f"Cannot create schema for {model_class} - try installing msgspec or pydantic"

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,5 +1,6 @@
+import sys
 from dataclasses import dataclass
-from typing import Any, Generic, TypedDict, TypeVar
+from typing import Any, Generic, TypeVar
 
 import pytest
 from attrs import define
@@ -9,6 +10,11 @@ from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from quart_schema.conversion import convert_headers, model_dump, model_load, model_schema
 from .helpers import ADetails, DCDetails, MDetails, PyDCDetails, PyDetails, TDetails, TGDetails
+
+if sys.version_info >= (3, 12):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class ValidationError(Exception):
@@ -150,7 +156,7 @@ class Resource(TypedDict, Generic[A, M]):
     modifier: M
 
 
-def test_nested_generic_ref_included():
+def test_nested_generic_ref_included() -> None:
     schema = model_schema(
         Resource[Attribute, Modifier],
         preference="msgspec",

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Any, Generic, TypedDict, TypeVar
 
 import pytest
 from attrs import define
@@ -130,6 +130,62 @@ def test_model_schema_msgspec(type_: TestType, preference: str) -> None:
         del expected["properties"]["age"]["default"]
 
     assert schema == expected
+
+
+A = TypeVar("A")
+M = TypeVar("M")
+
+
+class Modifier(TypedDict):
+    mod: int
+
+
+class Attribute(TypedDict):
+    title: str
+
+
+class Resource(TypedDict, Generic[A, M]):
+    foo: str
+    attribute: A
+    modifier: M
+
+
+def test_nested_generic_ref_included():
+    schema = model_schema(
+        Resource[Attribute, Modifier],
+        preference="msgspec",
+    )
+
+    assert schema == {
+        "title": "Resource[Attribute, Modifier]",
+        "type": "object",
+        "properties": {
+            "attribute": {
+                "$ref": "#/components/schemas/Attribute",
+            },
+            "modifier": {
+                "$ref": "#/components/schemas/Modifier",
+            },
+            "foo": {"type": "string"},
+        },
+        "required": ["attribute", "foo", "modifier"],
+        "$defs": {
+            "Attribute": {
+                "properties": {
+                    "title": {"type": "string"},
+                },
+                "required": ["title"],
+                "title": "Attribute",
+                "type": "object",
+            },
+            "Modifier": {
+                "properties": {"mod": {"type": "integer"}},
+                "required": ["mod"],
+                "title": "Modifier",
+                "type": "object",
+            },
+        },
+    }
 
 
 @define


### PR DESCRIPTION
As a followup to #120 I found that such `TypedDicts` with generics do generate references in the json schema returned by `msgspec` but these are not used in `quart-schema`. These references are now returned correctly. 

Should fix #117 