### PR TITLE
Accept single bare values for list-typed query parameters

### DIFF
--- a/docs/how_to_guides/querystring_validation.rst
+++ b/docs/how_to_guides/querystring_validation.rst
@@ -111,40 +111,14 @@ You may want to allow a repeated, multiple, or list query string
 parameter e.g. ``/?key=foo&key=bar``. Which can be done using
 ``list[str]`` for example.
 
-Care must be taken for the case where only a single parameter is given
-(as this is not as list). In this situation you can either expand the
-type to ``list[str] | str`` for example, or to convert the single value
-to a list using a ``BeforeValidator``,
+For a field declared as a ``list``, the following forms are accepted
+and equivalent,
 
-.. code-block:: python
+- ``/?key=foo`` - a single value, treated as a one-element list
+- ``/?key=foo&key=bar`` - repeated values
+- ``/?key[]=foo&key[]=bar`` - the ``[]`` suffix convention (used e.g.
+  by axios)
 
-    from typing import Annotated
-
-    from pydantic import BaseModel
-    from pydantic.functional_validators import BeforeValidator
-    from quart_schema import validate_querystring
-
-    def _to_list(value: str | list[str]) -> list[str]:
-        if isinstance(value, list):
-            return value
-        else:
-            return [value]
-
-    class Query(BaseModel):
-        keys: Annotated[Optional[List[str]], BeforeValidator(_to_list)] = None
-
-    @app.route("/")
-    @validate_querystring(Query)
-    async def index(query_args: Query):
-        ...
-
-.. warning::
-
-   This currently only works with Pydantic types and validation.
-
-List values with suffix
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Alternatively there is a convention to suffix query string parameters with ``[]``
-to indicate the parameter is a list. With this convention the case where only a
-single parameter is given will be considered a list
+Parameters that are not declared as a list must only be given once;
+repeating them (or adding the ``[]`` suffix) results in a 400
+response.

--- a/src/quart_schema/validation.py
+++ b/src/quart_schema/validation.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import auto, Enum
-from functools import wraps
-from typing import Any
+from functools import lru_cache, wraps
+from types import UnionType
+from typing import Any, get_args, get_origin, get_type_hints, Union
 
 from quart import current_app, request, Response
 from werkzeug.exceptions import BadRequest
 from werkzeug.wrappers import Response as WerkzeugResponse
 
+from .casing import camel_to_snake
 from .conversion import convert_headers, model_load
 from .typing import Model, ResponseReturnValue
 
@@ -51,6 +53,36 @@ class DataSource(Enum):
     JSON = auto()
 
 
+_LIST_CONTAINERS: tuple[type, ...] = (list, tuple, set, frozenset)
+
+
+@lru_cache(maxsize=128)
+def _list_field_names(model_class: type[Model]) -> frozenset[str]:
+    """Return the names of fields in *model_class* that expect list values.
+
+    Handles ``Optional``/``Union`` wrappers (e.g. ``list[int] | None``) and
+    caches results per model class for repeated calls.
+
+    Falls back to raw ``__annotations__`` if forward references cannot be
+    resolved.
+    """
+
+    def _expects_list(annotation: Any) -> bool:
+        origin = get_origin(annotation)
+        if origin in (Union, UnionType):
+            return any(_expects_list(arg) for arg in get_args(annotation))
+        if origin is not None:
+            return origin in _LIST_CONTAINERS
+        return annotation in _LIST_CONTAINERS
+
+    try:
+        hints = get_type_hints(model_class)
+    except (NameError, TypeError):
+        hints = getattr(model_class, "__annotations__", {})
+
+    return frozenset(name for name, annotation in hints.items() if _expects_list(annotation))
+
+
 def validate_querystring(model_class: type[Model]) -> Callable:
     """Validate the request querystring arguments.
 
@@ -63,6 +95,8 @@ def validate_querystring(model_class: type[Model]) -> Callable:
             dataclass or a class that inherits from pydantic's
             BaseModel. All the fields must be optional.
     """
+    # mypy can't prove type[Model] is hashable and lru_cache requires hashable arguments
+    list_fields = _list_field_names(model_class)  # type: ignore[arg-type]
 
     def decorator(func: Callable) -> Callable:
         setattr(func, QUART_SCHEMA_QUERYSTRING_ATTRIBUTE, model_class)
@@ -70,20 +104,26 @@ def validate_querystring(model_class: type[Model]) -> Callable:
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             request_args: dict[str, Any] = {}
+            decamelize = current_app.config["QUART_SCHEMA_CONVERT_CASING"]
+
             for key in request.args:
-                if key.endswith("[]"):
-                    request_args[key.removesuffix("[]")] = request.args.getlist(key)
+                # Strip [] suffix for array syntax
+                clean_key = key.removesuffix("[]") if key.endswith("[]") else key
+                # Apply casing conversion for model matching
+                model_key = camel_to_snake(clean_key) if decamelize else clean_key
+                values = request.args.getlist(key)
+
+                # List fields always get lists; scalars get single values
+                if len(values) > 1 or model_key in list_fields:
+                    request_args[model_key] = values
                 else:
-                    request_args[key] = (
-                        request.args.getlist(key)
-                        if len(request.args.getlist(key)) > 1
-                        else request.args[key]
-                    )
+                    request_args[model_key] = values[0] if values else None
+
             model = model_load(
                 request_args,
                 model_class,
                 QuerystringValidationError,
-                decamelize=current_app.config["QUART_SCHEMA_CONVERT_CASING"],
+                decamelize=decamelize,
                 preference=current_app.config["QUART_SCHEMA_CONVERSION_PREFERENCE"],
             )
             return await current_app.ensure_async(func)(*args, query_args=model, **kwargs)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -351,6 +351,7 @@ async def test_querystring_validation(path: str, status: int) -> None:
     "path, expected",
     [
         ("/", None),
+        ("/?elems=2", [2]),
         ("/?elems[]=2", [2]),
         ("/?elems=2&elems=3", [2, 3]),
         ("/?elems[]=2&elems[]=3", [2, 3]),


### PR DESCRIPTION
`validate_querystring` only produces a list when a key occurs more than once. For a field declared as `list[int]`, a client sending a one-item array gets a 400 instead of `[1]`.                                                                                                                                                      
                                                                                                                                                                              
This PR enhances `validate_querystring` to treat a single occurrence of a parameter declared as a list as a one-element list, based on the model's annotations. It works for all model kinds and keeps the existing `[]` suffix and repeated forms working.

The following requests are now treated equally:

```text
/?elems=2             -> 200 {"elems": [2]} # This was not possible without workaround before
/?elems[]=2           -> 200 {"elems": [2]}
/?elems=2&elems=3     -> 200 {"elems": [2, 3]}
/?elems[]=2&elems[]=3 -> 200 {"elems": [2, 3]}
```

---
<details>
Before, accepting a single value for a list field required special pydantic syntax (a ``BeforeValidator`` per field), which is now unnecessary (also wasnt really possible with msgspec):

```python
from typing import Annotated

from pydantic import BaseModel
from pydantic.functional_validators import BeforeValidator
from quart_schema import validate_querystring

def _to_list(value: str | list[str]) -> list[str]:
    if isinstance(value, list):
        return value
    else:
        return [value]

class Query(BaseModel):
    keys: Annotated[Optional[List[str]], BeforeValidator(_to_list)] = None

@app.route("/")
@validate_querystring(Query)
async def index(query_args: Query):
    ...
```

